### PR TITLE
Fix unsafe BPF_PROG_TEST_RUN interface

### DIFF
--- a/net/bpf/test_run.c
+++ b/net/bpf/test_run.c
@@ -55,8 +55,15 @@ static int bpf_test_finish(const union bpf_attr *kattr,
 {
 	void __user *data_out = u64_to_user_ptr(kattr->test.data_out);
 	int err = -EFAULT;
+	u32 copy_size = size;
 
-	if (data_out && copy_to_user(data_out, data, size))
+	/* Clamp copy if the user has provided a size hint, but copy the full
+	 * buffer if not to retain old behaviour.
+	 */
+	if (kattr->test.data_size_out && copy_size > kattr->test.data_size_out)
+		copy_size = kattr->test.data_size_out;
+
+	if (data_out && copy_to_user(data_out, data, copy_size))
 		goto out;
 	if (copy_to_user(&uattr->test.data_size_out, &size, sizeof(size)))
 		goto out;

--- a/tools/lib/bpf/bpf.c
+++ b/tools/lib/bpf/bpf.c
@@ -272,10 +272,12 @@ int bpf_prog_test_run(int prog_fd, int repeat, void *data, __u32 size,
 	attr.test.data_in = ptr_to_u64(data);
 	attr.test.data_out = ptr_to_u64(data_out);
 	attr.test.data_size_in = size;
+	if (data_out)
+		attr.test.data_size_out = *size_out;
 	attr.test.repeat = repeat;
 
 	ret = sys_bpf(BPF_PROG_TEST_RUN, &attr, sizeof(attr));
-	if (size_out)
+	if (data_out)
 		*size_out = attr.test.data_size_out;
 	if (retval)
 		*retval = attr.test.retval;


### PR DESCRIPTION
This is a backport of similarly named change that was pulled in
as part of addb0679839a1f74da6ec742137558be244dd0e9

bpf_prof_test_run may copy data beyond the the buffer provided into
userspace without checking the size. This can lead to kernel overwriting
data in userspace.

Original patch backported from https://patchwork.ozlabs.org/cover/998940/

Signed-off-by: Farid Zakaria <farid.m.zakaria@oracle.com>